### PR TITLE
Fiedler companion matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nalgebra = "0.32.2"
+nalgebra = "0.32.3"
 cached_proc_macro = "0.4.0"
 cached = "0.19.0"
 anyhow = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,12 +48,12 @@ mod tests {
         let a = -10.;
         let b = 10.;
         let N0 = 2;
-        let epsilon = 1E-9;
-        let truncation_threshold = 1E-13;
-        let N_max = 1000;
-        let complex_threshold = 1E-9;
-        let interval_limit = 1E-9;
-        let far_from_zero = 1E2;
+        let epsilon = 1E-3;
+        let truncation_threshold = 1E-9;
+        let N_max = 10000;
+        let complex_threshold = 1e-6;
+        let interval_limit = 1E-12;
+        let far_from_zero = 1E9;
 
         let roots = find_roots_piecewise_with_secant_polishing(&g, &f, vec![(a, -2E-4), (-2E-4, 0.0), (0.0, 2E-5), (2E-5, b)], N0, epsilon, N_max, complex_threshold, truncation_threshold, interval_limit, far_from_zero).unwrap();
         let num_roots = roots.len();
@@ -99,6 +99,7 @@ pub mod chebyshev {
     const SECANT_MAX_ITERATIONS: usize = 1000;
 
     use nalgebra::{DMatrix, DVector};
+    use nalgebra::linalg::balancing::balance_parlett_reinsch;
     use std::f64::consts::PI;
     use cached::proc_macro::cached;
     use anyhow::{Result, Context, anyhow};
@@ -107,7 +108,9 @@ pub mod chebyshev {
 
         //let A_jk = monomial_frobenius_matrix(c_j.into());
 
-        let B_jk = monomial_fiedler_matrix(c_j.into());
+        let mut B_jk = monomial_fiedler_matrix(c_j.into());
+
+        balance_parlett_reinsch(&mut B_jk);
 
         println!("{}", B_jk);
 
@@ -363,7 +366,9 @@ pub mod chebyshev {
                     roots.push(a_j[0])
                 }
 
-                let A = chebyshev_frobenius_matrix(a_j);
+                let mut A = chebyshev_frobenius_matrix(a_j);
+
+                balance_parlett_reinsch(&mut A);
 
                 let eigenvalues = A.complex_eigenvalues();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,6 @@ pub mod chebyshev {
 
         balance_parlett_reinsch(&mut B_jk);
 
-        println!("{}", B_jk);
-
         let roots = B_jk.complex_eigenvalues();
 
         Ok(roots.iter().filter(|x| (x.im).abs() <= complex_threshold).map(|x| x.re).collect::<Vec<f64>>())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,18 +72,9 @@ mod tests {
 
         //let g = |x: f64| x.powf(4.) + 4.2*x.powf(3.) - 1.8*x.powf(2.) - 13.*x + 9.6;
 
-        //let c_j: Vec<f64> = vec![1., 5.2, 3.4, -9.6];
+        let c_j: Vec<f64> = vec![1., 5.2, 3.4, -9.6];
 
-        let e = 1.602e-19;
-        let p = 1e-10;
-        let alpha = 4e-58;
-        let beta = 4e-97;
-
-        //let c_j: Vec<f64> = vec![1., -p*p, alpha/e, 1., beta/e];
-
-        let c_j: Vec<f64> = vec![1., 0., -p*p, 0., alpha/e, 0., 0., 0., -beta/e];
-
-        let roots = real_polynomial_roots(c_j.clone(), 1E-9).unwrap();
+        let roots = real_polynomial_roots(c_j.clone(), 1E-20).unwrap();
 
         println!("Roots are: 1, -3, -3.2");
 
@@ -118,8 +109,11 @@ pub mod chebyshev {
 
         let B_jk = monomial_fiedler_matrix(c_j.into());
 
+        println!("{}", B_jk);
+
         let roots = B_jk.complex_eigenvalues();
-        Ok(roots.iter().filter(|x| x.im <= complex_threshold).map(|x| x.re).collect::<Vec<f64>>())
+
+        Ok(roots.iter().filter(|x| (x.im).abs() <= complex_threshold).map(|x| x.re).collect::<Vec<f64>>())
 
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,6 @@ pub mod chebyshev {
 
     pub fn real_polynomial_roots(c_j: Vec<f64>, complex_threshold: f64) -> Result<Vec<f64>, anyhow::Error> {
 
-        //let A_jk = monomial_frobenius_matrix(c_j.into());
-
         let mut B_jk = monomial_fiedler_matrix(c_j.into());
 
         balance_parlett_reinsch(&mut B_jk);


### PR DESCRIPTION
Replace the monomial Frobenius companion matrix with a balanced Fiedler companion matrix. This should help prevent numerical issues when using the polynomial rootfinder.