### PR TITLE
Schur decomposition fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ pub mod chebyshev {
 
                 //If len(a_j) is 1, then its eigenvalue is simply itself, and the interval can be skipped.
                 if a_j.len() == 1 {
-                    roots.push(a_j[0]);
+                    roots.push(a_j[0]*(i.1 - i.0)/2. + (i.1 + i.0)/2.);
                     break
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ pub mod chebyshev {
 
                 balance_parlett_reinsch(&mut A);
 
-                let eps = 1e-9;
+                let eps = 1e-15;
                 let nmax = 1000;
                 if let Some(schur_matrix) = Schur::try_new(A, eps, nmax) {
                     let eigenvalues = schur_matrix.complex_eigenvalues();
@@ -376,12 +376,17 @@ pub mod chebyshev {
                         }
                     }
                 } else {
-                    break
+                    //println!("{} {} {} {} ", a, b, f(a), f(b));
+                    if let Ok(subroots) = find_roots(&f, vec![(i.0, (i.1 - i.0)/2.), ((i.1 - i.0)/2., i.1)], N0, epsilon, N_max, complex_threshold, truncation_threshold, interval_limit, far_from_zero) {
+                        for root in subroots {
+                            roots.push(root)
+                        }
+                    }
                 }
             }
             Ok(roots)
         } else {
-            Err(anyhow!("Subdivision reached interval limit without converging. Consider relaxing epsilon or increasing N_max. F(a) = {} F(b) = {}", f(a), f(b)))
+            Err(anyhow!("Subdivision reached interval limit without converging. Consider relaxing epsilon or increasing N_max. a = {} b = {} F(a) = {} F(b) = {}", a, b, f(a), f(b)))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,8 +493,8 @@ pub mod chebyshev {
     }
 
     fn chebyshev_coefficients(f: &dyn Fn(f64) -> f64, a: f64, b: f64, N: usize) -> DVector<f64> {
-        //Given a function and an interval [a, b], returns a vector of the Chebyshev interpolation
-        //coefficients on that interval.
+        //Given a function f and an interval [a, b], returns a vector of the Chebyshev interpolation
+        //coefficients on that interval of order N.
         let xk = lobatto_grid(a, b, N);
         let I_jk = interpolation_matrix(N);
         let f_xk: DVector<f64> = DVector::<f64>::from(xk.iter().map(|&x| f(x)).collect::<Vec<f64>>());
@@ -503,7 +503,7 @@ pub mod chebyshev {
     }
 
     fn lobatto_grid(a: f64, b: f64, N: usize) -> Vec<f64> {
-        //Returns a Lobatto Grid on the interval [a, b].
+        //Returns a Lobatto Grid on the interval [a, b] of order N.
         (0..=N).map(|k| (b - a)/2.*(PI*k as f64/N as f64).cos() + (b + a)/2.).collect::<Vec<f64>>()
     }
 
@@ -579,8 +579,10 @@ pub mod chebyshev {
     }
 
     fn chebyshev_adaptive(f: &dyn Fn(f64) -> f64, a: f64, b: f64, N0: usize, epsilon: f64, N_max: usize) -> (DVector<f64>, f64) {
-        //Adaptive Chebyshev approximation, which starts from degree N0 and doubles
-        //the degree each iteration.
+        //Adaptive Chebyshev approximation of the function f on the interval [a, b], which starts from degree N0 and doubles
+        //the degree each iteration until the error is less than epsilon, starting with order N0 returning the Chebyshev coefficients a if
+        //convergence is reached before the degree exceeds N_max.
+        //
         let mut a_0 = chebyshev_coefficients(f, a, b, N0);
         let mut N0 = N0;
 


### PR DESCRIPTION
This series of changes addresses a RustBCA issue ([#224](https://github.com/lcpp-org/RustBCA/issues/224)) and an nalgebra issue ([#611](https://github.com/dimforge/nalgebra/issues/611)).

In short, the eigenvalue solver in nalgebra can fail to converge for certain matrices. Older, more robust solvers, such as those in LAPACK, have multiple solvers to fall back on in these edge cases, but nalgebra does not. When it comes to RustBCA, there are certain matrices produced during the distance-of-closest-approach problem that fall into the class of matrices that cause convergence failure. In the original implementation, this results in a randomly occuring infinite loop.

By using a different form of the nalgebra eigenvalue solver that allows one to set a maximum number of iterations, this infinite loop can be broken. Instead of producing an error which will lead to a panic in RustBCA, I have found that simply taking the current interval on which rootfinding is being attempted and splitting it into two such intervals solves the problem with only one layer of recursion.

This makes rcpr significantly more robust.